### PR TITLE
Spotted these. 

### DIFF
--- a/linux-3.4-redquark/arch/arm/boot/compressed/head.S
+++ b/linux-3.4-redquark/arch/arm/boot/compressed/head.S
@@ -10,6 +10,7 @@
  */
 #include <linux/linkage.h>
 
+	.arch	armv7-a
 /*
  * Debugging stuff
  *
@@ -132,7 +133,61 @@ start:
 		.word	start			@ absolute load/run zImage address
 		.word	_edata			@ zImage end address
  THUMB(		.thumb			)
-1:		mov	r7, r1			@ save architecture ID
+1:
+
+/******************************************************************************/
+/*
+ * This is a hack to implement the compatibility check between the mainline
+ * U-Boot and the legacy sunxi-3.4 kernel. We interpret the top 4 bits of the
+ * machine id as a some sort of a machine id compatibility revision number.
+ *
+ * The expected workflow:
+ *
+ * 1. U-Boot introduces some changes, which may expose some serious bug in
+ *    the sunxi-3.4 kernel. For example, changes the PLL5P clock speed.
+ *    So that the kernel needs bugfixes like:
+ *        https://github.com/linux-sunxi/linux-sunxi/commit/9a1cd034181af628d41
+ *        https://github.com/linux-sunxi/linux-sunxi/commit/ade08aa6e5249a9e75a
+ *
+ *    And U-Boot bumps the compatibility revision number in the machine id at
+ *    the same time. For example, changes the 'include/configs/sun4i.h' from
+ *
+ *        #define CONFIG_MACH_TYPE 4104
+ *
+ *    into
+ *
+ *        #define CONFIG_MACH_TYPE_COMPAT_REV 1
+ *        #define CONFIG_MACH_TYPE (4104 | (CONFIG_MACH_TYPE_COMPAT_REV << 28))
+ *
+ * 2. The sunxi-3.4 kernel applies the necessary bugfixes to the code and also
+ *    bumps the CONFIG_MACH_TYPE_COMPAT_REV number in this file in the kernel.
+ *
+ * The effect of this is the following. If somebody tries to boot some old
+ * kernel with the new incompatible U-Boot, then the top bits of the machine
+ * id will be non-zero and the kernel will refuse to load because of the
+ * machine id mismatch. The appropriate error message will show on the serial
+ * console, and this error message is very much googlable. The linux-sunxi wiki
+ * can contain the necessary explanations about how to resolve this situation.
+ *
+ * If somebody tries to boot an appropriately fixed revison of the sunxi-3.4
+ * kernel with the new U-Boot, then the top 4 bits of the machine id will be
+ * cleared by the code in this assembly file after passing the revision check.
+ *
+ * If somebody tries to boot an appropriately fixed revison of the sunxi-3.4
+ * kernel with a very old U-Boot (for example, the legacy u-boot-sunxi), then
+ * everything will be fine too.
+ */
+		#define CONFIG_MACH_TYPE_COMPAT_REV 1
+
+		/* Extract the machine id compatibility revision number */
+		mov	r7, r1, lsr #28
+		cmp	r7, #CONFIG_MACH_TYPE_COMPAT_REV
+		/* Clear the top 4 bits if the compatibility check succeeded */
+		bicle	r1, r1, #(0xF << 28)
+
+/******************************************************************************/
+
+		mov	r7, r1			@ save architecture ID
 		mov	r8, r2			@ save atags pointer
 
 #ifndef __ARM_ARCH_2__

--- a/linux-3.4-redquark/arch/arm/mach-sun7i/dma/dma_interface.c
+++ b/linux-3.4-redquark/arch/arm/mach-sun7i/dma/dma_interface.c
@@ -91,7 +91,7 @@ dma_hdl_t sw_dma_request(char * name, dma_chan_type_e type)
 	dma_channel_t *pchan = NULL;
 
 	DMA_DBG("%s: name %s, chan type %d\n", __func__, name, (u32)type);
-	if((name && strlen(name) >= MAX_NAME_LEN) || (type != CHAN_NORAML && type != CHAN_DEDICATE)) {
+	if((name && strlen(name) >= MAX_NAME_LEN) || (type != CHAN_NORMAL && type != CHAN_DEDICATE)) {
 		DMA_ERR("%s: para err, name %s, type %d\n", __func__, name, (u32)type);
 		return NULL;
 	}
@@ -103,7 +103,7 @@ dma_hdl_t sw_dma_request(char * name, dma_chan_type_e type)
 		goto end;
 	}
 	/* get a free channel */
-	if(CHAN_NORAML == type)
+	if(CHAN_NORMAL == type)
 		i = 0;
 	else
 		i = 8;

--- a/linux-3.4-redquark/arch/arm/mach-sun7i/include/mach/dma.h
+++ b/linux-3.4-redquark/arch/arm/mach-sun7i/include/mach/dma.h
@@ -234,7 +234,7 @@ typedef struct {
 
 /* dma channel type */
 typedef enum {
-	CHAN_NORAML,		/* normal channel, id 0~7 */
+	CHAN_NORMAL,		/* normal channel, id 0~7 */
 	CHAN_DEDICATE,		/* dedicate channel, id 8~15 */
 }dma_chan_type_e;
 

--- a/linux-3.4-redquark/arch/arm/mm/proc-v7.S
+++ b/linux-3.4-redquark/arch/arm/mm/proc-v7.S
@@ -259,18 +259,7 @@ __v7_setup:
 	mcr	p15, 0, r5, c10, c2, 0		@ write PRRR
 	mcr	p15, 0, r6, c10, c2, 1		@ write NMRR
 #endif
-#ifndef CONFIG_ARM_THUMBEE
-	mrc	p15, 0, r0, c0, c1, 0		@ read ID_PFR0 for ThumbEE
-	and	r0, r0, #(0xf << 12)		@ ThumbEE enabled field
-	teq	r0, #(1 << 12)			@ check if ThumbEE is present
-	bne	1f
-	mov	r5, #0
-	mcr	p14, 6, r5, c1, c0, 0		@ Initialize TEEHBR to 0
-	mrc	p14, 6, r0, c0, c0, 0		@ load TEECR
-	orr	r0, r0, #1			@ set the 1st bit in order to
-	mcr	p14, 6, r0, c0, c0, 0		@ stop userspace TEEHBR access
-1:
-#endif
+	dsb					@ Complete invalidations
 #ifndef CONFIG_ARM_THUMBEE
 	mrc	p15, 0, r0, c0, c1, 0		@ read ID_PFR0 for ThumbEE
 	and	r0, r0, #(0xf << 12)		@ ThumbEE enabled field

--- a/linux-3.4-redquark/drivers/spi/spi-sun7i.c
+++ b/linux-3.4-redquark/drivers/spi/spi-sun7i.c
@@ -535,7 +535,7 @@ static int sun7i_spi_config_dma(struct sun7i_spi *aw_spi, enum spi_dma_dir dma_d
     spi_hw_conf.bconti_mode                 = false;
     spi_hw_conf.irq_spt                     = CHAN_IRQ_FD;
     switch (aw_spi->dma_type) {
-        case CHAN_NORAML:
+        case CHAN_NORMAL:
             if (SPI_DMA_RDEV == dma_dir) {
                 spi_hw_conf.address_type.src_addr_mode  = NDMA_ADDR_NOCHANGE;
                 spi_hw_conf.address_type.dst_addr_mode  = NDMA_ADDR_INCREMENT;
@@ -1455,12 +1455,12 @@ static int __init sun7i_spi_probe(struct platform_device *pdev)
     aw_spi->master          = master;
     aw_spi->irq             = irq;
 #ifdef CONFIG_SUN7I_SPI_NDMA
-	aw_spi->dma_type        = CHAN_NORAML;
+	aw_spi->dma_type        = CHAN_NORMAL;
 #else
 	aw_spi->dma_type        = CHAN_DEDICATE;
 #endif
 	spi_inf("%s: spi%d dma type: %s\n", __func__, pdev->id,
-			aw_spi->dma_type == CHAN_NORAML ? "normal" : "dedicate");
+			aw_spi->dma_type == CHAN_NORMAL ? "normal" : "dedicate");
     aw_spi->dma_id_tx       = dma_res_tx->start;
     aw_spi->dma_id_rx       = dma_res_rx->start;
     aw_spi->dma_hdle_rx     = 0;

--- a/linux-3.4-redquark/drivers/usb/sun7i_usb/udc/sw_udc_dma.c
+++ b/linux-3.4-redquark/drivers/usb/sun7i_usb/udc/sw_udc_dma.c
@@ -506,7 +506,7 @@ __s32 sw_udc_dma_probe(struct sw_udc *dev)
 		p[strlen(p) + 1] = 0;
 		p[strlen(p)] = i + '0';
 
-		dev->sw_udc_dma[i].dma_hdle = sw_dma_request(dev->sw_udc_dma[i].name, CHAN_NORAML);
+		dev->sw_udc_dma[i].dma_hdle = sw_dma_request(dev->sw_udc_dma[i].name, CHAN_NORMAL);
 		if(dev->sw_udc_dma[i].dma_hdle == 0) {
 			DMSG_PANIC("ERR: sw_dma_request failed\n");
 			return -1;

--- a/linux-3.4-redquark/sound/soc/sun7i/hdcp/sun7i-hdcpdma.c
+++ b/linux-3.4-redquark/sound/soc/sun7i/hdcp/sun7i-hdcpdma.c
@@ -274,7 +274,7 @@ static int sun7i_pcm_hw_params(struct snd_pcm_substream *substream,
 				/*
 		 * requeset audio dma handle(we don't care about the channel!)
 		 */
-		play_prtd->dma_hdl = sw_dma_request(play_prtd->params->name, CHAN_NORAML);
+		play_prtd->dma_hdl = sw_dma_request(play_prtd->params->name, CHAN_NORMAL);
 		if (NULL == play_prtd->dma_hdl) {
 			printk(KERN_ERR "failed to request spdif dma handle\n");
 			return -EINVAL;
@@ -323,7 +323,7 @@ static int sun7i_pcm_hw_params(struct snd_pcm_substream *substream,
 				/*
 		 * requeset audio dma handle(we don't care about the channel!)
 		 */
-		capture_prtd->dma_hdl = sw_dma_request(capture_prtd->params->name, CHAN_NORAML);
+		capture_prtd->dma_hdl = sw_dma_request(capture_prtd->params->name, CHAN_NORMAL);
 		if (NULL == capture_prtd->dma_hdl) {
 			printk(KERN_ERR "failed to request spdif dma handle\n");
 			return -EINVAL;

--- a/linux-3.4-redquark/sound/soc/sun7i/i2s/sun7i-i2sdma.c
+++ b/linux-3.4-redquark/sound/soc/sun7i/i2s/sun7i-i2sdma.c
@@ -274,7 +274,7 @@ static int sun7i_pcm_hw_params(struct snd_pcm_substream *substream,
 				/*
 		 * requeset audio dma handle(we don't care about the channel!)
 		 */
-		play_prtd->dma_hdl = sw_dma_request(play_prtd->params->name, CHAN_NORAML);
+		play_prtd->dma_hdl = sw_dma_request(play_prtd->params->name, CHAN_NORMAL);
 		if (NULL == play_prtd->dma_hdl) {
 			printk(KERN_ERR "failed to request spdif dma handle\n");
 			return -EINVAL;
@@ -323,7 +323,7 @@ static int sun7i_pcm_hw_params(struct snd_pcm_substream *substream,
 				/*
 		 * requeset audio dma handle(we don't care about the channel!)
 		 */
-		capture_prtd->dma_hdl = sw_dma_request(capture_prtd->params->name, CHAN_NORAML);
+		capture_prtd->dma_hdl = sw_dma_request(capture_prtd->params->name, CHAN_NORMAL);
 		if (NULL == capture_prtd->dma_hdl) {
 			printk(KERN_ERR "failed to request spdif dma handle\n");
 			return -EINVAL;

--- a/linux-3.4-redquark/sound/soc/sun7i/pcm/sun7i-pcmdma.c
+++ b/linux-3.4-redquark/sound/soc/sun7i/pcm/sun7i-pcmdma.c
@@ -270,7 +270,7 @@ static int sun7i_pcm_hw_params(struct snd_pcm_substream *substream,
 				/*
 		 * requeset audio dma handle(we don't care about the channel!)
 		 */
-		play_prtd->dma_hdl = sw_dma_request(play_prtd->params->name, CHAN_NORAML);
+		play_prtd->dma_hdl = sw_dma_request(play_prtd->params->name, CHAN_NORMAL);
 		if (NULL == play_prtd->dma_hdl) {
 			printk(KERN_ERR "failed to request spdif dma handle\n");
 			return -EINVAL;
@@ -319,7 +319,7 @@ static int sun7i_pcm_hw_params(struct snd_pcm_substream *substream,
 				/*
 		 * requeset audio dma handle(we don't care about the channel!)
 		 */
-		capture_prtd->dma_hdl = sw_dma_request(capture_prtd->params->name, CHAN_NORAML);
+		capture_prtd->dma_hdl = sw_dma_request(capture_prtd->params->name, CHAN_NORMAL);
 		if (NULL == capture_prtd->dma_hdl) {
 			printk(KERN_ERR "failed to request spdif dma handle\n");
 			return -EINVAL;

--- a/linux-3.4-redquark/sound/soc/sun7i/spdif/sun7i_spdma.c
+++ b/linux-3.4-redquark/sound/soc/sun7i/spdif/sun7i_spdma.c
@@ -138,7 +138,7 @@ static int sun7i_pcm_hw_params(struct snd_pcm_substream *substream,
 		/*
 		 * requeset audio dma handle(we don't care about the channel!)
 		 */
-		prtd->dma_hdl = sw_dma_request(prtd->params->name, CHAN_NORAML);
+		prtd->dma_hdl = sw_dma_request(prtd->params->name, CHAN_NORMAL);
 		if (NULL == prtd->dma_hdl) {
 			printk(KERN_ERR "failed to request spdif dma handle\n");
 			return -EINVAL;

--- a/linux-3.4-redquark/sound/soc/sun7i/sun7i-codec.c
+++ b/linux-3.4-redquark/sound/soc/sun7i/sun7i-codec.c
@@ -863,7 +863,7 @@ static int sun7i_codec_pcm_hw_params(struct snd_pcm_substream *substream, struct
 			/*
 			 * requeset audio dma handle(we don't care about the channel!)
 			 */
-			play_prtd->dma_hdl = sw_dma_request(play_prtd->params->name, CHAN_NORAML);
+			play_prtd->dma_hdl = sw_dma_request(play_prtd->params->name, CHAN_NORMAL);
 			//sw_dma_dump_chan(play_prtd->dma_hdl);
 			if (NULL == play_prtd->dma_hdl) {
 				printk(KERN_ERR "failed to request spdif dma handle\n");
@@ -903,7 +903,7 @@ static int sun7i_codec_pcm_hw_params(struct snd_pcm_substream *substream, struct
 			/*
 			 * requeset audio dma handle(we don't care about the channel!)
 			 */
-			capture_prtd->dma_hdl = sw_dma_request(capture_prtd->params->name, CHAN_NORAML);
+			capture_prtd->dma_hdl = sw_dma_request(capture_prtd->params->name, CHAN_NORMAL);
 			if (NULL == capture_prtd->dma_hdl) {
 				printk(KERN_ERR "failed to request spdif dma handle\n");
 				return -EINVAL;


### PR DESCRIPTION
Maybe we should add somewhere that some of the scripts and configs from http://dl.linux-sunxi.org/SDK/A20/ could be useful? I adapted the scripts and config slightly from there and have it and buildroot build a nice rootfs, it produced a boot image i haven't tested yet, i could not crack open 'nanda' with eithere abootimg-tools or the bootimgtools scripts, I'm not happy about everything being armv5 either. It should be something like -march=armv7-a+simd+vfpv4-16d -mcpu cortex-a7 but these clash horribly in early gcc's at leat.  